### PR TITLE
catch connection error endpoint

### DIFF
--- a/src/orchestrator/api/views.py
+++ b/src/orchestrator/api/views.py
@@ -149,6 +149,8 @@ class IoTConf(Stats):
             rstatus = status.HTTP_403_FORBIDDEN
         elif code == 409:
             rstatus = status.HTTP_409_CONFLICT
+        elif code == 500:
+            rstatus = status.HTTP_500_INTERNAL_SERVER_ERROR
         else:
             rstatus = status.HTTP_400_BAD_REQUEST
         return rstatus

--- a/src/orchestrator/common/util.py
+++ b/src/orchestrator/common/util.py
@@ -35,12 +35,14 @@ class RestOperations(object):
     '''
 
     def __init__(self,
+                 ENDPOINT_NAME="",
                  PROTOCOL=None,
                  HOST=None,
                  PORT=None,
                  CORRELATOR_ID=None,
                  TRANSACTION_ID=None):
 
+        self.ENDPOINT_NAME = ENDPOINT_NAME
         self.PROTOCOL = PROTOCOL
         self.HOST = HOST
         self.PORT = PORT
@@ -141,10 +143,15 @@ class RestOperations(object):
                 if data_json and isinstance(data_json, dict) and \
                     'message' in data_json:
                     res.msg = data_json['message']
+
             except ValueError:
                 res.msg = data
             except Exception, e:
                 print e
+        except urllib2.URLError, e:
+            res = e
+            res.code = 500
+            res.msg = self.ENDPOINT_NAME + " endpoint ERROR: " + res.args[0][1]
 
         return res
 

--- a/src/orchestrator/core/iota_cpp.py
+++ b/src/orchestrator/core/iota_cpp.py
@@ -44,7 +44,8 @@ class IoTACppOperations(object):
         self.IOTA_HOST = IOTA_HOST
         self.IOTA_PORT = IOTA_PORT
 
-        self.IoTACppRestOperations = RestOperations(IOTA_PROTOCOL,
+        self.IoTACppRestOperations = RestOperations("IOTA",
+                                                    IOTA_PROTOCOL,
                                                     IOTA_HOST,
                                                     IOTA_PORT,
                                                     CORRELATOR_ID,

--- a/src/orchestrator/core/keypass.py
+++ b/src/orchestrator/core/keypass.py
@@ -45,7 +45,8 @@ class AccCKeypassOperations(AccCOperations):
         self.KEYPASS_HOST = KEYPASS_HOST
         self.KEYPASS_PORT = KEYPASS_PORT
 
-        self.AccessControlRestOperations = RestOperations(KEYPASS_PROTOCOL,
+        self.AccessControlRestOperations = RestOperations("KEYPASS",
+                                                          KEYPASS_PROTOCOL,
                                                           KEYPASS_HOST,
                                                           KEYPASS_PORT,
                                                           CORRELATOR_ID,

--- a/src/orchestrator/core/keystone.py
+++ b/src/orchestrator/core/keystone.py
@@ -45,7 +45,8 @@ class IdMKeystoneOperations(IdMOperations):
         self.KEYSTONE_HOST = KEYSTONE_HOST
         self.KEYSTONE_PORT = KEYSTONE_PORT
 
-        self.IdMRestOperations = RestOperations(KEYSTONE_PROTOCOL,
+        self.IdMRestOperations = RestOperations("KEYSTONE",
+                                                KEYSTONE_PROTOCOL,
                                                 KEYSTONE_HOST,
                                                 KEYSTONE_PORT,
                                                 TRANSACTION_ID)

--- a/src/orchestrator/core/orion.py
+++ b/src/orchestrator/core/orion.py
@@ -44,7 +44,8 @@ class CBOrionOperations(object):
         self.CB_HOST = CB_HOST
         self.CB_PORT = CB_PORT
 
-        self.CBRestOperations = RestOperations(CB_PROTOCOL,
+        self.CBRestOperations = RestOperations("ORION",
+                                               CB_PROTOCOL,
                                                CB_HOST,
                                                CB_PORT,
                                                CORRELATOR_ID,


### PR DESCRIPTION
With this PR and endpoint connection error like:
```
 msg=<urlopen error [Errno 113] No route to host>
```
will be:
```
KEYPASS endpoint ERROR: No route to host
```
and HTTP 400 code will be HTTP 500 error code

- [x] Tested cents6 / python2.6
- [x] Tested centos7 / python2.7
