### PR TITLE
check response before calculate size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+FIX: error trace reported when metrics are trying to calculate error response size [#84]
 FEATURE: allow non positional args in docker entrypoint [#78]
 
 1.5.2

--- a/src/orchestrator/common/util.py
+++ b/src/orchestrator/common/util.py
@@ -271,7 +271,8 @@ class RestOperations(object):
             else:
                 self.sum["outgoingTransactionErrors"] += 1
             self.sum["outgoingTransactionRequestSize"] += len(json.dumps(data_request)) + len(str(headers_request))
-            self.sum["outgoingTransactionResponseSize"] += len(json.dumps(data_response)) + len(str(response.headers.headers))
+            # Check headers
+            self.sum["outgoingTransactionResponseSize"] += len(json.dumps(data_response)) + len(str(response.headers.headers)) if headers in response else 0
             self.sum["serviceTimeTotal"] += (service_stop - service_start)
         except Exception, ex:
             self.logger.error("ERROR collecting outgoing metrics %s", ex)


### PR DESCRIPTION
This is a minor bug, just a trace error was reported.

fix issue https://github.com/telefonicaid/orchestrator/issues/84


This fix solve these kind of traces:
```
iot-orchestrator            | time=2017-08-18T10:58:41.294Z | lvl=ERROR | corr=8f0e1307-670a-47ab-98dd-33f34c39040e | trans=8f0e1307-670a-47ab-98dd-33f34c39040e | srv=smartavila | subsrv=/murallas | comp=Orchestrator | op=orchestrator_core:collectOutgoingMetrics() | msg=ERROR collecting outgoing metrics 'URLError' object has no attribute 'headers'
```