### PR TITLE
replace error by warn trace when trying to remove elements in third parties

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-FIX: replace error by warn trace when trying to remove elements in third parties [#80]
+FIX: replace error by warn trace when trying to remove elements in third parties [#83]
 FIX: set pepperseo conf after perseo conf in docker [#82]
 FEATURE: allow non positional args in docker entrypoint [#78]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+FIX: replace error by warn trace when trying to remove elements in third parties [#80]
 FEATURE: allow non positional args in docker entrypoint [#78]
 
 1.5.2

--- a/src/orchestrator/core/orion.py
+++ b/src/orchestrator/core/orion.py
@@ -339,7 +339,7 @@ class CBOrionOperations(object):
             logger.debug("subscriptions: %s" % json.dumps(subscriptions,
                                                           indent=3))
         except Exception, ex:
-            logger.error("%s trying getListSubscriptions from CB: %s/%s" % (ex,
+            logger.warn("%s trying getListSubscriptions from CB: %s/%s" % (ex,
                                 SERVICE_NAME,
                                 SUBSERVICE_NAME))
             return subscriptions_deleted
@@ -352,7 +352,7 @@ class CBOrionOperations(object):
                                         subscription['id'])
                 subscriptions_deleted.append(subscription['id'])
             except Exception, ex:
-                logger.error("%s trying to unsubscribe context: %s" % (ex,
+                logger.warn("%s trying to unsubscribe context: %s" % (ex,
                                                         subscription['id']))
         return subscriptions_deleted
 

--- a/src/orchestrator/core/perseo.py
+++ b/src/orchestrator/core/perseo.py
@@ -91,7 +91,7 @@ class PerseoOperations(object):
             logger.debug("rules: %s" % json.dumps(rules, indent=3))
 
         except Exception, ex:
-            logger.error("%s trying getRules from PERSEO: %s/%s" % (ex,
+            logger.warn("%s trying getRules from PERSEO: %s/%s" % (ex,
                                                                     SERVICE_NAME,
                                                                     SUBSERVICE_NAME))
             return rules_deleted
@@ -114,7 +114,7 @@ class PerseoOperations(object):
                 assert res.code == 204, (res.code, res.msg)
                 rules_deleted.append(rule['name'])
             except Exception, ex:
-                logger.error("%s trying to remove rule: %s" % (ex,
+                logger.warn("%s trying to remove rule: %s" % (ex,
                                                                rule['name']))
 
         return rules_deleted


### PR DESCRIPTION
Fix issue https://github.com/telefonicaid/orchestrator/issues/83

Orchestrator is trying to delete in perseo/orion with insufficient token privileges, so these errors are false errors.

```
iot-orchestrator            | time=2017-08-18T10:58:41.395Z | lvl=ERROR | corr=8f0e1307-670a-47ab-98dd-33f34c39040e | trans=8f0e1307-670a-47ab-98dd-33f34c39040e | srv=smartavila | subsrv=/murallas | comp=Orchestrator | op=orchestrator_core:deleteAllSubscriptions() | msg=(401, u'The provided token does not belong to the provided service.') trying getListSubscriptions from CB: smartavila/
```