### PR TITLE
do not log in error level all 400 codes, just do it in debug level

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+FEATURE: Do not log as error level requests with codes > 400 and < 500
 FIX: Init orchestrator_core logger with empty values for startup errors
 
 1.6.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-FEATURE: Do not log as error level requests with codes > 400 and < 500
+FEATURE: Log in debug level all requests with codes > 400 and < 500
 FIX: Init orchestrator_core logger with empty values for startup errors
 
 1.6.0

--- a/src/orchestrator/core/flow/Domains.py
+++ b/src/orchestrator/core/flow/Domains.py
@@ -73,8 +73,10 @@ class Domains(FlowBase):
             self.logger.debug("DOMAINS=%s" % json.dumps(DOMAINS, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
+
 
         data_log = {
             "DOMAINS": DOMAINS
@@ -139,8 +141,9 @@ class Domains(FlowBase):
             self.logger.debug("DOMAIN=%s" % json.dumps(DOMAIN, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "DOMAIN": DOMAIN
@@ -211,8 +214,9 @@ class Domains(FlowBase):
             self.logger.debug("DOMAIN=%s" % json.dumps(DOMAIN, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "DOMAIN": DOMAIN
@@ -355,8 +359,9 @@ class Domains(FlowBase):
             self.logger.debug("DOMAIN=%s" % DOMAIN)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "DOMAIN": DOMAIN
@@ -473,8 +478,9 @@ class Domains(FlowBase):
                 raise Exception("not admin role found to perform this action")
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "POLICIES": policies
@@ -591,8 +597,9 @@ class Domains(FlowBase):
             self.logger.debug("subscription id=%s" % subscriptionid)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "subscriptionid": subscriptionid
@@ -688,8 +695,9 @@ class Domains(FlowBase):
             # self.logger.debug("subscription id=%s" % subscriptionid)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "subscriptionid": subscriptionid
@@ -768,8 +776,9 @@ class Domains(FlowBase):
             self.logger.debug("modules=%s" % json.dumps(modules, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "modules": modules

--- a/src/orchestrator/core/flow/Groups.py
+++ b/src/orchestrator/core/flow/Groups.py
@@ -95,8 +95,9 @@ class Groups(FlowBase):
                                                                indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_GROUPS": SERVICE_GROUPS,
@@ -162,8 +163,9 @@ class Groups(FlowBase):
             self.logger.debug("DETAIL_GROUP=%s" % json.dumps(DETAIL_GROUP, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "DETAIL_GROUP": DETAIL_GROUP,
@@ -250,8 +252,9 @@ class Groups(FlowBase):
                                  GROUP_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "GROUP_ID": GROUP_ID,
@@ -338,8 +341,9 @@ class Groups(FlowBase):
                                  GROUP_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "GROUP_ID": GROUP_ID
@@ -422,8 +426,9 @@ class Groups(FlowBase):
             self.logger.debug("ID of group %s: %s" % (NEW_SERVICE_GROUP_NAME, ID_GROUP))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,

--- a/src/orchestrator/core/flow/Projects.py
+++ b/src/orchestrator/core/flow/Projects.py
@@ -89,8 +89,9 @@ class Projects(FlowBase):
             self.logger.debug("PROJECTS=%s" % json.dumps(PROJECTS, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "PROJECTS": PROJECTS
@@ -175,8 +176,9 @@ class Projects(FlowBase):
             self.logger.debug("PROJECT=%s" % PROJECT)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "PROJECT": PROJECT
@@ -266,8 +268,9 @@ class Projects(FlowBase):
             self.logger.debug("PROJECT=%s" % PROJECT)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "PROJECT": PROJECT
@@ -390,8 +393,9 @@ class Projects(FlowBase):
             self.logger.debug("PROJECT=%s" % PROJECT)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "PROJECT": PROJECT
@@ -795,8 +799,9 @@ class Projects(FlowBase):
 
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ENTITY_ID": ENTITY_ID,
@@ -1138,8 +1143,9 @@ class Projects(FlowBase):
 
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
 
@@ -1272,8 +1278,9 @@ class Projects(FlowBase):
                 DEVICES_ID.append(res)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "devices": DEVICES_ID
@@ -1371,8 +1378,9 @@ class Projects(FlowBase):
 
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
 
@@ -1516,8 +1524,9 @@ class Projects(FlowBase):
             self.logger.debug("subscription id=%s" % subscriptionid)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "subscriptionid": subscriptionid
@@ -1633,8 +1642,9 @@ class Projects(FlowBase):
                     break
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "subscriptionid": subscriptionid
@@ -1735,8 +1745,9 @@ class Projects(FlowBase):
             self.logger.debug("modules=%s" % json.dumps(modules, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "modules": modules

--- a/src/orchestrator/core/flow/Roles.py
+++ b/src/orchestrator/core/flow/Roles.py
@@ -103,8 +103,9 @@ class Roles(FlowBase):
             self.logger.debug("ROLES=%s" % json.dumps(ROLES, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ROLES": ROLES
@@ -292,8 +293,9 @@ class Roles(FlowBase):
             self.logger.debug("ROLES=%s" % json.dumps(role_assignments_expanded,
                                                  indent=3))
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "role_assignments": role_assignments_expanded,
@@ -423,8 +425,9 @@ class Roles(FlowBase):
                                      SERVICE_USER_ID,
                                      ROLE_ID)
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,
@@ -559,8 +562,9 @@ class Roles(FlowBase):
                                       ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SUBSERVICE_ID": "%s" % SUBSERVICE_ID,
@@ -670,8 +674,9 @@ class Roles(FlowBase):
                                       INHERIT_ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_USER": "%s" % SERVICE_USER_ID,
@@ -782,8 +787,9 @@ class Roles(FlowBase):
                                       ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,
@@ -910,8 +916,9 @@ class Roles(FlowBase):
                                        ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SUBSERVICE_ID": "%s" % SUBSERVICE_ID,
@@ -1020,8 +1027,9 @@ class Roles(FlowBase):
                                        SERVICE_USER_ID,
                                        INHERIT_ROLE_ID)
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_USER": "%s" % SERVICE_USER_ID,
@@ -1209,8 +1217,9 @@ class Roles(FlowBase):
             self.logger.debug("ROLES=%s" % json.dumps(role_assignments_expanded,
                                                  indent=3))
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "role_assignments": role_assignments_expanded,
@@ -1341,8 +1350,9 @@ class Roles(FlowBase):
                                      SERVICE_GROUP_ID,
                                      ROLE_ID)
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,
@@ -1478,8 +1488,9 @@ class Roles(FlowBase):
                                             ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SUBSERVICE_ID": "%s" % SUBSERVICE_ID,
@@ -1590,8 +1601,9 @@ class Roles(FlowBase):
                                              INHERIT_ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_GROUP": "%s" % SERVICE_GROUP_ID,
@@ -1703,8 +1715,9 @@ class Roles(FlowBase):
                                              ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,
@@ -1832,8 +1845,9 @@ class Roles(FlowBase):
                                               ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SUBSERVICE_ID": "%s" % SUBSERVICE_ID,
@@ -1942,8 +1956,9 @@ class Roles(FlowBase):
                                               SERVICE_GROUP_ID,
                                               INHERIT_ROLE_ID)
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_GROUP": "%s" % SERVICE_GROUP_ID,
@@ -2030,8 +2045,9 @@ class Roles(FlowBase):
                                 ROLE_ID)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ROLE_ID": ROLE_ID
@@ -2143,8 +2159,9 @@ class Roles(FlowBase):
                 raise Exception("not admin role found to perform this action")
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -2254,8 +2271,9 @@ class Roles(FlowBase):
                 raise Exception("not admin role found to perform this action")
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -2364,8 +2382,9 @@ class Roles(FlowBase):
                 raise Exception("not admin role found to perform this action")
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/Users.py
+++ b/src/orchestrator/core/flow/Users.py
@@ -108,8 +108,9 @@ class Users(FlowBase):
             # Listar los usuarios de un Subservicio
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_USERS": SERVICE_USERS,
@@ -175,8 +176,9 @@ class Users(FlowBase):
             self.logger.debug("DETAIL_USER=%s" % json.dumps(DETAIL_USER, indent=3))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "DETAIL_USER": DETAIL_USER,

--- a/src/orchestrator/core/flow/base.py
+++ b/src/orchestrator/core/flow/base.py
@@ -154,6 +154,16 @@ class FlowBase(object):
         return res, None, None
 
 
+    def logError(self, logger, error_code, ex):
+        '''
+        Log as error level error_code if is < 400 or > 500
+        '''
+        if (error_code[0]['code'] < 400 or error_code[0]['code'] > 500):
+            logger.error(ex)
+        else:
+            logger.debug(ex)
+
+
     def get_endpoint_iot_module(self, iot_module):
         assert iot_module in IOTMODULES
         if iot_module in self.endpoints:

--- a/src/orchestrator/core/flow/createNewService.py
+++ b/src/orchestrator/core/flow/createNewService.py
@@ -333,8 +333,9 @@ class CreateNewService(FlowBase):
                     self.idm.deleteDomain(DOMAIN_ADMIN_TOKEN, ID_DOM1)
                 except Exception, ex:
                     self.logger.warn("%s trying to remove uncomplete created domain %s" % (ex, ID_DOM1))
-            self.logger.error("error creating new service: %s" % ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_DOM1": "%s" % ID_DOM1,

--- a/src/orchestrator/core/flow/createNewServiceRole.py
+++ b/src/orchestrator/core/flow/createNewServiceRole.py
@@ -128,8 +128,9 @@ class CreateNewServiceRole(FlowBase):
                                         POLICY_FILE_NAME='policy-keypass-customer2.xml')
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,

--- a/src/orchestrator/core/flow/createNewServiceUser.py
+++ b/src/orchestrator/core/flow/createNewServiceUser.py
@@ -108,8 +108,9 @@ class CreateNewServiceUser(FlowBase):
             self.logger.debug("ID of user %s: %s" % (NEW_USER_NAME, ID_USER))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,

--- a/src/orchestrator/core/flow/createNewSubService.py
+++ b/src/orchestrator/core/flow/createNewSubService.py
@@ -154,8 +154,9 @@ class CreateNewSubService(FlowBase):
                 self.logger.info("removing uncomplete created project %s" % ID_PRO1)
                 self.idm.disableProject(SERVICE_ADMIN_TOKEN, SERVICE_ID, ID_PRO1)
                 self.idm.deleteProject(SERVICE_ADMIN_TOKEN, ID_PRO1)
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "SERVICE_ID": "%s" % SERVICE_ID,

--- a/src/orchestrator/core/flow/createTrustToken.py
+++ b/src/orchestrator/core/flow/createTrustToken.py
@@ -179,8 +179,9 @@ class CreateTrustToken(FlowBase):
             self.logger.debug("ID of Trust %s" % (ID_TRUST))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "ID_TRUST": "%s" % ID_TRUST
@@ -275,8 +276,9 @@ class CreateTrustToken(FlowBase):
             self.logger.debug("Trusts %s" % (TRUSTS))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "TRUSTS": "%s" % TRUSTS

--- a/src/orchestrator/core/flow/removeUser.py
+++ b/src/orchestrator/core/flow/removeUser.py
@@ -105,8 +105,9 @@ class RemoveUser(FlowBase):
             # self.logger.debug("ID of user %s: %s" % (USER_NAME, ID_USER))
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "USER_ID": USER_ID

--- a/src/orchestrator/core/flow/updateUser.py
+++ b/src/orchestrator/core/flow/updateUser.py
@@ -106,8 +106,9 @@ class UpdateUser(FlowBase):
                                 USER_DATA_VALUE)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "USER_ID": USER_ID,
@@ -197,8 +198,9 @@ class UpdateUser(FlowBase):
                                         NEW_USER_PASSWORD)
 
         except Exception, ex:
-            self.logger.error(ex)
-            return self.composeErrorCode(ex)
+            error_code = self.composeErrorCode(ex)
+            self.logError(self.logger, error_code, ex)
+            return error_code
 
         data_log = {
             "USER_ID": USER_ID,


### PR DESCRIPTION
Currently all 400 errors (including typical 401 and 403)  were logged on error level. But there is no reason to do that, just debug is enough,

This PR will result in minor logs and better performance.