### PR TITLE
Task/disable uwsgi stats

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 CHANGES
 =======
 
+FEATURE: Remove uwsgi stats: takes too much time
+
 1.8.0
 
 FEATURE: LDAP support for user management

--- a/bin/orchestrator-daemon.sh
+++ b/bin/orchestrator-daemon.sh
@@ -17,7 +17,6 @@ VIRTUALENV=/var/env-orchestrator
 ORCHESTRATOR_DIR=${VIRTUALENV}/lib/python2.6/site-packages/iotp-orchestrator
 UWGSI=/var/env-orchestrator/bin/uwsgi
 PORT=8084
-STATS_PORT=8085
 PROCESSES=2
 THREADS=8
 ENVIRONMENT="DJANGO_SETTINGS_MODULE=settings.dev"
@@ -38,8 +37,7 @@ exe="$UWGSI --http :${PORT} \
 --processes $PROCESSES \
 --threads $THREADS \
 --enable-threads \
---disable-logging \
---stats localhost:$STATS_PORT"
+--disable-logging"
 
 server="$exe"
 

--- a/bin/orchestrator-entrypoint.sh
+++ b/bin/orchestrator-entrypoint.sh
@@ -3,7 +3,6 @@
 
 # DEFAULT SETTINGS
 PORT=8084
-STATS_PORT=8085
 PROCESSES=2
 THREADS=8
 ENVIRONMENT="DJANGO_SETTINGS_MODULE=settings.dev"
@@ -223,5 +222,4 @@ uwsgi --http :$PORT \
       --processes $PROCESSES \
       --threads $THREADS \
       --enable-threads \
-      --disable-logging \
-      --stats localhost:$STATS_PORT
+      --disable-logging


### PR DESCRIPTION
- Uwsgi stats add overhead to each operation (between 30% - 40%  more)
- Nobody reads uwsgi stats