### PR TITLE
Fix/default ldap port

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+2.0.1
+
+FIX: check ldap port before cast to int
+
 2.0.0
 
 FEATURE: Create Orion indexes needed for each service in MongoDB [#145]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = iotp_orchestrator
-version = 2.0.0
+version = 2.0.1
 summary = IoT Platform Orchestrator
 description-file =
     README.md

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 ############################ COMMON PROPERTIES
 sonar.projectName=Orchestrator
 sonar.projectKey=com.telefonica.iot:orchestrator
-sonar.projectVersion=2.0.0
+sonar.projectVersion=2.0.1
 
 ### SOURCES AND EXCLUSIONS
 sonar.sources=src

--- a/src/orchestrator/api/iotconf.py
+++ b/src/orchestrator/api/iotconf.py
@@ -94,8 +94,8 @@ class IoTConf(Stats):
             self.LDAP_PORT = settings.LDAP['port']
             self.LDAP_BASEDN = settings.LDAP['basedn']
         except KeyError:
-            logger.error("LDAP endpoint configuration error. " +
-                         "Forcing to use default conf values (localhost)")
+            logger.warn("LDAP endpoint configuration error. " +
+                        "Forcing to use default conf values (localhost)")
             self.LDAP_HOST = "localhost"
             self.LDAP_PORT = "389"
             self.LDAP_BASEDN = "dc=openstack,dc=org"
@@ -108,8 +108,8 @@ class IoTConf(Stats):
             self.MAILER_FROM = settings.MAILER['from']
             self.MAILER_TO = settings.MAILER['to']
         except KeyError:
-            logger.error("MAILER endpoint configuration error. " +
-                         "Forcing to use default conf values (localhost)")
+            logger.warn("MAILER endpoint configuration error. " +
+                        "Forcing to use default conf values (localhost)")
             self.MAILER_HOST = "localhost"
             self.MAILER_PORT = "587"
             self.MAILER_USER = "smtpuser@yourdomain.com"

--- a/src/orchestrator/core/openldap.py
+++ b/src/orchestrator/core/openldap.py
@@ -43,7 +43,7 @@ class OpenLdapOperations(object):
                  CORRELATOR_ID=None,
                  TRANSACTION_ID=None):
         self.LDAP_HOST = LDAP_HOST
-        self.LDAP_PORT = int(LDAP_PORT)
+        self.LDAP_PORT = int(LDAP_PORT) if LDAP_PORT else 0
         self.LDAP_BASEDN = LDAP_BASEDN
 
     def checkLdap(self):


### PR DESCRIPTION
- [x] change log level of this kind of log:
```
time=2018-05-21T15:28:02.528Z | lvl=ERROR | corr=n/a | trans=n/a | srv=None | subsrv=/ | comp=Orchestrator | op=orchestrator_api:__init__() | msg=MAILER endpoint configuration error. Forcing to use default conf values (localhost)
```
- [x] fix error starting ldap without ldapport