### PR TITLE
add parse --with-python27 arg to spec

### DIFF
--- a/orchestrator.spec
+++ b/orchestrator.spec
@@ -59,7 +59,7 @@ mkdir -p $RPM_BUILD_ROOT/etc/default
 cp -a %{_root}/bin/orchestrator-daemon $RPM_BUILD_ROOT/etc/default/orchestrator-daemon
 
 %files
-"/var/env-orchestrator/lib/python2.6/site-packages/iotp-orchestrator"
+%{python_lib}/iotp-orchestrator
 %defattr(755,%{_project_user},%{_project_user},755)
 %config /etc/init.d/%{_service_name}
 %config /etc/default/%{_service_name}-daemon

--- a/package-orchestrator.sh
+++ b/package-orchestrator.sh
@@ -35,6 +35,7 @@ source $BASE/get_version_string.sh
 string=$(get_rpm_version_string)
 VERSION_VALUE=${string% *}
 RELEASE_VALUE=${string#* }
+PYTHON27_VALUE=0
 
 args=("$@")
 ELEMENTS=${#args[@]}
@@ -46,6 +47,9 @@ for (( i=0;i<$ELEMENTS;i++)); do
     fi
     if [ "$arg" == "--with-release" ]; then
         RELEASE_VALUE=${args[${i}+1]}
+    fi
+    if [ "$arg" == "--with-python27" ]; then
+        PYTHON27_VALUE=1
     fi
 done
 
@@ -59,5 +63,6 @@ rpmbuild -bb orchestrator.spec \
   --define "_topdir $RPM_DIR" \
   --define "_root $BASE"\
   --define "_project_user $ORCHESTRATOR_USER"\
+  --define "with_python27 $PYTHON27_VALUE"\
   --define "_version $VERSION_VALUE"\
   --define "_release $RELEASE_VALUE"


### PR DESCRIPTION
RPM for python2.6
./package-orchestrator.sh --with-version 2.3 --with-release 0

RPM for python2.7
./package-orchestrator.sh --with-version 2.3 --with-release 0 --with-python27