### PR TITLE
allow . and : in subservice name and bump to 2.5.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 CHANGES
 =======
 
+ADD: Allow subservices names with ':' and '.'
+
 2.4.0
 
 FIX: startup orchestrator is not executed (#190)

--- a/src/orchestrator/api/schemas.py
+++ b/src/orchestrator/api/schemas.py
@@ -205,7 +205,7 @@ json = {
             "NEW_SUBSERVICE_NAME": {
                 "type": "string",
                 "maxLength": 50,
-                "pattern": "^([A-Za-z0-9_/]+)$",
+                "pattern": "^([A-Za-z0-9_/.:]+)$",
             },
             "NEW_SUBSERVICE_DESCRIPTION": {
                 "type": "string",


### PR DESCRIPTION
Allow `.` and `:` in subservice(project) names
Similar to previous PR https://github.com/telefonicaid/orchestrator/pull/174