### PR TITLE
Update djangorestframework

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+UPDATE: Update Djangorestframework to 3.9.4 due to security vulnerability
 Add STH mongodb indexes to optimize queries on its collections (#192)
 Add TLS option to mailer configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.11.20
-djangorestframework==3.9.0
+djangorestframework==3.9.4
 httplib2==0.12.0
 simplejson==3.16.0
 jsonschema==2.5.0


### PR DESCRIPTION

WS-2019-0037 More information
moderate severity
Vulnerable versions: < 3.9.1
Patched version: 3.9.1

Django-Rest-Framework, before 3.9.1, has a XSS vulnerability caused by disabled autoescaping in the default DRF Browsable API view templates.