### PR TITLE
add dynamic header buffer size

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+UPDATE: Allow header buffer size customization from execution args. If is not received the default is 4KB
 FIX: rename multiagent to multisink cygnus option
 
 2.10.0

--- a/bin/orchestrator-entrypoint.sh
+++ b/bin/orchestrator-entrypoint.sh
@@ -62,6 +62,8 @@ MONGODB_URI='localhost:27017'
 PEP_PASSWORD=pep
 IOTAGENT_PASSWORD=iotagent
 
+UWSGI_BUFFER_SIZE=4096
+
 while [[ $# -gt 0 ]]; do
     PARAM=`echo $1`
     VALUE=`echo $2`
@@ -152,6 +154,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -debuglevel)
             DEBUG_LEVEL=$VALUE
+            ;;
+        -uwsgibuffersize)
+            UWSGI_BUFFER_SIZE=$VALUE
             ;;
         *)
             echo "not found"
@@ -313,4 +318,5 @@ uwsgi --http :$PORT \
       --max-requests $MAX_REQUESTS \
       --vacuum \
       --enable-threads \
-      --disable-logging
+      --disable-logging \
+      --buffer-size  $UWSGI_BUFFER_SIZE


### PR DESCRIPTION
According to [UWSGI doc](https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html) the default value for uWSGI  headers requests is 4096 bytes. 

In this PR the default value is set to 4096 bytes but is possible to set a different value by received arguments on startup.