### PR TITLE
change log level from info to debug in some summary logs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+UPDATE: Change log level of summaries logs from info to debug to avoid extra load
 UPDATE: Update Django from 1.11.26 to 1.11.27 due to security vulnerability
 UPDATE: Makes optional create default generic roles when create a new domain
 

--- a/src/orchestrator/core/flow/Domains.py
+++ b/src/orchestrator/core/flow/Domains.py
@@ -81,7 +81,7 @@ class Domains(FlowBase):
         data_log = {
             "DOMAINS": DOMAINS
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log,
+        self.logger.debug("Summary report : %s" % json.dumps(data_log,
                                                        indent=3))
 
         # Consolidate opetions metrics into flow metrics
@@ -148,7 +148,7 @@ class Domains(FlowBase):
         data_log = {
             "DOMAIN": DOMAIN
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log,
+        self.logger.debug("Summary report : %s" % json.dumps(data_log,
                                                        indent=3))
 
         # Consolidate opetions metrics into flow metrics
@@ -221,7 +221,7 @@ class Domains(FlowBase):
         data_log = {
             "DOMAIN": DOMAIN
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -310,7 +310,7 @@ class Domains(FlowBase):
                         DOMAIN_NAME,
                         PROJECT_NAME)
                     if (len(subscriptions_deleted) > 0):
-                        self.logger.info("subscriptions deleted %s",
+                        self.logger.debug("subscriptions deleted %s",
                                          subscriptions_deleted)
 
                     #
@@ -320,7 +320,7 @@ class Domains(FlowBase):
                                                                DOMAIN_NAME,
                                                                PROJECT_NAME)
                     if (len(rules_deleted) > 0):
-                        self.logger.info("rules deleted %s",
+                        self.logger.debug("rules deleted %s",
                                          rules_deleted)
 
                 #
@@ -330,7 +330,7 @@ class Domains(FlowBase):
                     ADMIN_TOKEN,
                     DOMAIN_NAME)
                 if (len(subscriptions_deleted) > 0):
-                    self.logger.info("subscriptions deleted %s", subscriptions_deleted)
+                    self.logger.debug("subscriptions deleted %s", subscriptions_deleted)
 
 
                 #
@@ -340,7 +340,7 @@ class Domains(FlowBase):
                                                            DOMAIN_NAME,
                                                            "")
                 if (len(rules_deleted) > 0):
-                    self.logger.info("rules deleted %s",
+                    self.logger.debug("rules deleted %s",
                                      rules_deleted)
 
 
@@ -363,7 +363,7 @@ class Domains(FlowBase):
         data_log = {
             "DOMAIN": DOMAIN
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log,
+        self.logger.debug("Summary report : %s" % json.dumps(data_log,
                                                        indent=3))
 
         # Consolidate opetions metrics into flow metrics
@@ -482,7 +482,7 @@ class Domains(FlowBase):
         data_log = {
             "POLICIES": policies
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log,
+        self.logger.debug("Summary report : %s" % json.dumps(data_log,
                                                        indent=3))
 
         # Consolidate opetions metrics into flow metrics
@@ -591,7 +591,7 @@ class Domains(FlowBase):
         data_log = {
             "subscriptionid": subscriptionid
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -685,7 +685,7 @@ class Domains(FlowBase):
         data_log = {
             "subscriptionid": subscriptionid
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -766,7 +766,7 @@ class Domains(FlowBase):
         data_log = {
             "modules": modules
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/Groups.py
+++ b/src/orchestrator/core/flow/Groups.py
@@ -102,7 +102,7 @@ class Groups(FlowBase):
         data_log = {
             "SERVICE_GROUPS": SERVICE_GROUPS,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -170,7 +170,7 @@ class Groups(FlowBase):
         data_log = {
             "DETAIL_GROUP": DETAIL_GROUP,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -262,7 +262,7 @@ class Groups(FlowBase):
         data_log = {
             "GROUP_ID": GROUP_ID,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -351,7 +351,7 @@ class Groups(FlowBase):
         data_log = {
             "GROUP_ID": GROUP_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -437,7 +437,7 @@ class Groups(FlowBase):
             "SERVICE_ID": "%s" % SERVICE_ID,
             "ID_GROUP": "%s" % ID_GROUP,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/Projects.py
+++ b/src/orchestrator/core/flow/Projects.py
@@ -96,7 +96,7 @@ class Projects(FlowBase):
         data_log = {
             "PROJECTS": PROJECTS
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -185,7 +185,7 @@ class Projects(FlowBase):
         data_log = {
             "PROJECT": PROJECT
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -277,7 +277,7 @@ class Projects(FlowBase):
         data_log = {
             "PROJECT": PROJECT
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -362,7 +362,7 @@ class Projects(FlowBase):
                                                               DOMAIN_NAME,
                                                               PROJECT_NAME)
             if (len(subscriptions_deleted) > 0):
-                self.logger.info("subscriptions deleted %s",
+                self.logger.debug("subscriptions deleted %s",
                                  subscriptions_deleted)
 
             #
@@ -372,7 +372,7 @@ class Projects(FlowBase):
                                                        DOMAIN_NAME,
                                                        PROJECT_NAME)
             if (len(rules_deleted) > 0):
-                self.logger.info("rules deleted %s",
+                self.logger.debug("rules deleted %s",
                                  rules_deleted)
 
             PROJECT = self.idm.disableProject(ADMIN_TOKEN,
@@ -392,7 +392,7 @@ class Projects(FlowBase):
         data_log = {
             "PROJECT": PROJECT
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log,
+        self.logger.debug("Summary report : %s" % json.dumps(data_log,
                                                        indent=3))
 
         # Consolidate opetions metrics into flow metrics
@@ -528,7 +528,7 @@ class Projects(FlowBase):
         data_log = {
             "subscriptionid": subscriptionid
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -646,7 +646,7 @@ class Projects(FlowBase):
         data_log = {
             "subscriptionid": subscriptionid
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -749,7 +749,7 @@ class Projects(FlowBase):
         data_log = {
             "modules": modules
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/Roles.py
+++ b/src/orchestrator/core/flow/Roles.py
@@ -110,7 +110,7 @@ class Roles(FlowBase):
         data_log = {
             "ROLES": ROLES
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -300,7 +300,7 @@ class Roles(FlowBase):
         data_log = {
             "role_assignments": role_assignments_expanded,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -434,7 +434,7 @@ class Roles(FlowBase):
             "SERVICE_USER_ID": "%s" % SERVICE_USER_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -571,7 +571,7 @@ class Roles(FlowBase):
             "SERVICE_USER_ID": "%s" % SERVICE_USER_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -682,7 +682,7 @@ class Roles(FlowBase):
             "ID_USER": "%s" % SERVICE_USER_ID,
             "INHERIT_ROLE_ID": "%s" % INHERIT_ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -796,7 +796,7 @@ class Roles(FlowBase):
             "SERVICE_USER_ID": "%s" % SERVICE_USER_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -925,7 +925,7 @@ class Roles(FlowBase):
             "SERVICE_USER_ID": "%s" % SERVICE_USER_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1035,7 +1035,7 @@ class Roles(FlowBase):
             "ID_USER": "%s" % SERVICE_USER_ID,
             "INHERIT_ROLE_ID": "%s" % INHERIT_ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1227,7 +1227,7 @@ class Roles(FlowBase):
         data_log = {
             "role_assignments": role_assignments_expanded,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1362,7 +1362,7 @@ class Roles(FlowBase):
             "SERVICE_GROUP_ID": "%s" % SERVICE_GROUP_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1500,7 +1500,7 @@ class Roles(FlowBase):
             "SERVICE_GROUP_ID": "%s" % SERVICE_GROUP_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1612,7 +1612,7 @@ class Roles(FlowBase):
             "ID_GROUP": "%s" % SERVICE_GROUP_ID,
             "INHERIT_ROLE_ID": "%s" % INHERIT_ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1727,7 +1727,7 @@ class Roles(FlowBase):
             "SERVICE_GROUP_ID": "%s" % SERVICE_GROUP_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1857,7 +1857,7 @@ class Roles(FlowBase):
             "SERVICE_GROUP_ID": "%s" % SERVICE_GROUP_ID,
             "ROLE_ID": "%s" % ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -1967,7 +1967,7 @@ class Roles(FlowBase):
             "ID_GROUP": "%s" % SERVICE_GROUP_ID,
             "INHERIT_ROLE_ID": "%s" % INHERIT_ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -2055,7 +2055,7 @@ class Roles(FlowBase):
         data_log = {
             "ROLE_ID": ROLE_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/Users.py
+++ b/src/orchestrator/core/flow/Users.py
@@ -115,7 +115,7 @@ class Users(FlowBase):
         data_log = {
             "SERVICE_USERS": SERVICE_USERS,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -183,7 +183,7 @@ class Users(FlowBase):
         data_log = {
             "DETAIL_USER": DETAIL_USER,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/removeUser.py
+++ b/src/orchestrator/core/flow/removeUser.py
@@ -112,7 +112,7 @@ class RemoveUser(FlowBase):
         data_log = {
             "USER_ID": USER_ID
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()

--- a/src/orchestrator/core/flow/updateUser.py
+++ b/src/orchestrator/core/flow/updateUser.py
@@ -113,7 +113,7 @@ class UpdateUser(FlowBase):
         data_log = {
             "USER_ID": USER_ID,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()
@@ -205,7 +205,7 @@ class UpdateUser(FlowBase):
         data_log = {
             "USER_ID": USER_ID,
         }
-        self.logger.info("Summary report : %s" % json.dumps(data_log, indent=3))
+        self.logger.debug("Summary report : %s" % json.dumps(data_log, indent=3))
 
         # Consolidate opetions metrics into flow metrics
         self.collectComponentMetrics()


### PR DESCRIPTION
changing from info to debug we are avoiding json.dumps ops, which increases cpu load.