### PR TITLE
FIX wrong index creation 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+FIX: Orion index creation (was `_id.creDate: 1` and has to be `creDate: 1`)
 REMOVE: Remove unussed dependency repoze.lru
 UPDATE: include `from` in loggger  based on forwarded header
 UPDATE: Add skip initial notification to iot module (template subscription) (#293)

--- a/src/orchestrator/core/mongo.py
+++ b/src/orchestrator/core/mongo.py
@@ -55,7 +55,7 @@ class MongoDBOperations(object):
             db.entities.create_index([("_id.servicePath", pymongo.ASCENDING),
                                       ("_id.id", pymongo.ASCENDING),
                                       ("_id.type", pymongo.ASCENDING)])
-            db.entities.create_index("_id.creDate")
+            db.entities.create_index("creDate")
         except Exception, e:
             logger.warn("createIndex database %s exception: %s" % (databaseName,e))
 


### PR DESCRIPTION
According to https://fiware-orion.readthedocs.io/en/master/admin/perf_tuning/index.html#database-indexes, the index is just `creDate`, not `_id.creDate`.

I have just changed in one place. It is enough or some other changes are needed?