### PR TITLE
ADD missing geoloc and expiration indexes to Orion service provision

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 CHANGES
 =======
 
+FIX: create geo-index in Orion DB upon service provision (#301)
+FIX: cratee expiration index in Orion DB upon service provision
 Upgrade Dockerfile base image from centos7.7.1908 to centos7.9.2009
 
 3.7.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ CHANGES
 =======
 
 FIX: create geo-index in Orion DB upon service provision (#301)
-FIX: cratee expiration index in Orion DB upon service provision
+FIX: create expiration index in Orion DB upon service provision
 Upgrade Dockerfile base image from centos7.7.1908 to centos7.9.2009
 
 3.7.0

--- a/src/orchestrator/core/mongo.py
+++ b/src/orchestrator/core/mongo.py
@@ -52,6 +52,8 @@ class MongoDBOperations(object):
             # For Orion
             databaseName = 'orion-' + SERVICE_NAME
             db = self.client[databaseName]
+            db.entities.create_index([("location.coords", pymongo.GEOSPHERE)])
+            db.entities.create_index("expDate", expireAfterSeconds=0)
             db.entities.create_index([("_id.servicePath", pymongo.ASCENDING),
                                       ("_id.id", pymongo.ASCENDING),
                                       ("_id.type", pymongo.ASCENDING)])


### PR DESCRIPTION
Issue #301 

In addition, I have taken the opportunity to add another index that would be needed (for transient entities expiration)