### PR TITLE
Update orion.py: remove use skipInitialNotification orion option

### DIFF
--- a/src/orchestrator/core/orion.py
+++ b/src/orchestrator/core/orion.py
@@ -97,7 +97,7 @@ class CBOrionOperations(object):
         )
 
         res = self.CBRestOperations.rest_request(
-            url='/v2/subscriptions?options=skipInitialNotification',
+            url='/v2/subscriptions',
             method='POST',
             data=body_data,
             auth_token=SERVICE_USER_TOKEN,


### PR DESCRIPTION
Since Orion is saying: 

time=2023-04-12T10:45:48.165Z | lvl=WARN | corr=7ab449c6-16b7-47e3-a583-83369bc849e4 | trans=N/A | from=N/A | srv=N/A | subsrv=N/A | comp=Orion | op=ConnectionInfo.cpp[75]:isValidOption | msg=skipInitialNotification is no longer supported, please avoid using it
