### PR TITLE
fix print ex for python 3 when token error (i.e. token expited)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 CHANGES
 =======
+
+FIX: bad error reported (500 instead 401) when a token error (i.e. token expired)
+
 4.7.0
 
 UPGRADE: uwsgi version from 2.0.23 to 2.0.24

--- a/src/orchestrator/core/flow/base.py
+++ b/src/orchestrator/core/flow/base.py
@@ -275,7 +275,7 @@ class FlowBase(object):
                 # Probably expired?
                 token_extended  = {
                     "token": USER_TOKEN,
-                    "error": ex.message
+                    "error": str(ex)
                 }
         return token_extended
 


### PR DESCRIPTION
There is a worng handled error about print a exception (since orch uses python3) related to get a token (i.e. when a token is expired):


time=2024-04-02T09:49:58.916Z | lvl=ERROR | corr=n/a | trans=n/a | from=n/a | srv=None | subsrv=/ | comp=Orchestrator | op=django.request:log_response() | msg=Internal Server Error: /v1.0/service/9f710408f5944c3993db600810e97c83/user
Traceback (most recent call last):
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/base.py", line 258, in get_extended_token
    token_detail = self.idm.getTokenDetail(USER_TOKEN)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/keystone.py", line 1725, in getTokenDetail
    assert res.code == 200, (res.code, res.msg)
           ^^^^^^^^^^^^^^^
AssertionError: (401, 'auth_context did not decode anything useful (Disable insecure_debug mode to suppress these details.)')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/api/views.py", line 773, in get
    result, service_name, subservice_name = flow.users(
                                            ^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/Users.py", line 58, in users
    "SERVICE_ADMIN_TOKEN": self.get_extended_token(SERVICE_ADMIN_TOKEN),
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/base.py", line 278, in get_extended_token
    "error": ex.message
             ^^^^^^^^^^
AttributeError: 'AssertionError' object has no attribute 'message'
time=2024-04-02T09:49:58.916Z | lvl=ERROR | corr=n/a | trans=n/a | from=n/a | srv=None | subsrv=/ | comp=Orchestrator | op=django.request:log_response() | msg=Internal Server Error: /v1.0/service/9f710408f5944c3993db600810e97c83/user
Traceback (most recent call last):
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/base.py", line 258, in get_extended_token
    token_detail = self.idm.getTokenDetail(USER_TOKEN)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/keystone.py", line 1725, in getTokenDetail
    assert res.code == 200, (res.code, res.msg)
           ^^^^^^^^^^^^^^^
AssertionError: (401, 'auth_context did not decode anything useful (Disable insecure_debug mode to suppress these details.)')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 505, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 465, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 476, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.11/dist-packages/rest_framework/views.py", line 502, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/api/views.py", line 773, in get
    result, service_name, subservice_name = flow.users(
                                            ^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/Users.py", line 58, in users
    "SERVICE_ADMIN_TOKEN": self.get_extended_token(SERVICE_ADMIN_TOKEN),
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/env-orchestrator/lib/python3.11/site-packages/iotp-orchestrator/orchestrator/core/flow/base.py", line 278, in get_extended_token
    "error": ex.message
             ^^^^^^^^^^
AttributeError: 'AssertionError' object has no attribute 'message'
