### PR TITLE
[WIP] upgrade minor version of django-rest-framework dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.25
-djangorestframework==3.15.1
+djangorestframework==3.15.2
 jsonschema==2.6.0
 uwsgi==2.0.24
 requests==2.32.0


### PR DESCRIPTION
djangorestframework 3.15.2 depends on django>=4.2 and python > 3.8