### PR TITLE
Update Dockerfile: fix default port if not provided

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 CHANGES
 =======
 
+Fix: healthcheck when no PORT env var is provided (#386)
+
 4.10.0
 
 FIX: metrics usage are the same by all process/threads (#58)

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,4 +75,4 @@ ENTRYPOINT ["/opt/orchestrator/bin/orchestrator-entrypoint.sh"]
 EXPOSE ${PORT:-8084} ${STATS_PORT:-8184}
 
 HEALTHCHECK --interval=60s --timeout=5s --start-period=10s \
-            CMD curl --fail -X GET http://localhost:${PORT}/v1.0/version || exit 1
+            CMD curl --fail -X GET http://localhost:${PORT:-8084}/v1.0/version || exit 1


### PR DESCRIPTION
When no env var about PORT is given.

related https://github.com/telefonicaid/orchestrator/pull/382

https://github.com/telefonicasc/operation/issues/359#issuecomment-2765797106

fix for https://github.com/telefonicaid/orchestrator/issues/386