### PR TITLE
Remove component role assignment in createNewService.py

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+REMOVE: Do not assign component roles when create admin service when create new service (#412)
 UPGRADE: requests from 2.32.4 to 2.33.1 due to CVE-2026-25645
 UPGRADE: Debian version from 12.12 to 13.5 in Dockerfile
 UPGRADE: uwsgi version from 2.0.28 to 2.0.31

--- a/src/orchestrator/core/flow/createNewService.py
+++ b/src/orchestrator/core/flow/createNewService.py
@@ -250,14 +250,15 @@ class CreateNewService(FlowBase):
                                       ID_DOM1,
                                       ID_ADM1,
                                       ID_NEW_SERVICE_ROLE_SUBSERVICEADMIN)
-
-            for component in components:
-                self.idm.grantDomainRole(DOMAIN_ADMIN_TOKEN, ID_DOM1, ID_ADM1,
-                                         ID_NEW_SERVICE_ROLE_ADMIN_SET[component])
-                self.idm.grantInheritRole(NEW_SERVICE_ADMIN_TOKEN,
-                                          ID_DOM1,
-                                          ID_ADM1,
-                                          ID_NEW_SERVICE_ROLE_SUBSERVICEADMIN_SET[component])
+ 
+            # Do not assign admin service to component roles
+            # for component in components:
+            #    self.idm.grantDomainRole(DOMAIN_ADMIN_TOKEN, ID_DOM1, ID_ADM1,
+            #                             ID_NEW_SERVICE_ROLE_ADMIN_SET[component])
+            #    self.idm.grantInheritRole(NEW_SERVICE_ADMIN_TOKEN,
+            #                              ID_DOM1,
+            #                              ID_ADM1,
+            #                              ID_NEW_SERVICE_ROLE_SUBSERVICEADMIN_SET[component])
 
             #
             # 5. Provision default platform roles AccessControl policies


### PR DESCRIPTION
Commented out the role assignment for components in createNewService.py.